### PR TITLE
Adds ability to fetch CMs from library file instead of requiring individual CM files in ribotyper

### DIFF
--- a/ribo.pm
+++ b/ribo.pm
@@ -61,6 +61,7 @@ require $ribo_sequip_dir . "/sqp_utils.pm";
 # ribo_RemoveListOfDirsWithRmrf
 # ribo_WriteAcceptFile
 # ribo_CheckForTimeExecutable
+# ribo_ParseStoredIndiCmFileName
 #
 #################################################################
 # Subroutine : ribo_CountAmbiguousNucleotidesInSequenceFile()
@@ -1653,6 +1654,42 @@ sub ribo_GetDirPath {
   
   if($orig_file eq "") { return "./";       }
   else                 { return $orig_file; }
+}
+
+#################################################################
+# Subroutine : ribo_ParseStoredIndiCmFileName()
+# Incept:      EPN, Wed Oct 23 14:45:41 2024
+#
+# Purpose:     Parse a stored indi CM file name.
+#              If it matches: "fetch:<filename>" then
+#              we will fetch the model from a CM library file named <filename>
+#
+# Arguments: 
+#   $stored_indi_cmfile: string that is the CM file name, potentially
+#                        starting with 'fetch:'.
+# 
+# Returns:     Two values:
+#              $cmfile:   path to the CM file
+#              $do_fetch: '1' if we should fetch the CM from the $cmfile,
+#                         '0' if $cmfile is a single CM file that we don't
+#                         need to fetch from
+#
+################################################################# 
+sub ribo_ParseStoredIndiCmFileName { 
+  my $narg_expected = 1;
+  my $sub_name = "ribo_ParseStoredIndiCmFileName()";
+  if(scalar(@_) != $narg_expected) { printf STDERR ("ERROR, in $sub_name, entered with %d != %d input arguments.\n", scalar(@_), $narg_expected); exit(1); } 
+  my $stored_indi_cmfile = $_[0];
+  
+  my $cmfile = $stored_indi_cmfile;
+  my $do_fetch = undef;
+
+  if($cmfile =~ /^fetch\:/) {
+    $cmfile =~ s/^fetch\://;
+    $do_fetch = 1;
+  }
+
+  return ($cmfile, $do_fetch);
 }
 
 ###########################################################################

--- a/ribotyper
+++ b/ribotyper
@@ -1321,7 +1321,7 @@ sub parse_modelinfo_file {
       if(scalar(@el_A) != 4) { 
         ofile_FAIL("ERROR didn't read 4 tokens in model info input file $modelinfo_file, line $line", 1, $FH_HR);
       }
-      my($model, $family, $domain, $cmfile) = (@el_A);
+      my ($model, $family, $domain, $cmfile) = (@el_A);
 
       if($cmfile ne "-") { 
         # make sure that the model file exists
@@ -1335,6 +1335,16 @@ sub parse_modelinfo_file {
         }
         $found_master = 1;
         $master_cmfile = $cmfile;
+        # ensure the cmfile has been indexed, we need either $master_cmfile.ssi or all 4 of $master_cmfile.i1{m,f,p,i}
+        if(! utl_FileValidateExistsAndNonEmpty($master_cmfile . ".ssi", undef, $sub_name, 0, $FH_HR)) { # don't die if it doesn't exist
+          my $has_i1m = utl_FileValidateExistsAndNonEmpty($master_cmfile . ".i1m", undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
+          my $has_i1f = utl_FileValidateExistsAndNonEmpty($master_cmfile . ".i1f", undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
+          my $has_i1p = utl_FileValidateExistsAndNonEmpty($master_cmfile . ".i1p", undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
+          my $has_i1i = utl_FileValidateExistsAndNonEmpty($master_cmfile . ".i1i", undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
+          if((! $has_i1m) || (! $has_i1f) || (! $has_i1p) || (! $has_i1i)) {
+            ofile_FAIL("ERROR master model file is not indexed.\nEither\n\t$master_cmfile.ssi\nmust exist (creatable by 'cmfetch --index')\n\nOR\n\nAll 4 of\n\t$master_cmfile.i1m\n\t$master_cmfile.i1f\n\t$master_cmfile.i1p\n\t$master_cmfile.i1i\nmust exist (createable by 'cmpress'.", $sub_name, 1, $FH_HR);
+          }
+        }
         if($master_cmfile =~ m/\.cm$/) { 
           $master_blastdb_file = $cmfile;
           $master_blastdb_file =~ s/\.cm$/.fa/;

--- a/ribotyper
+++ b/ribotyper
@@ -1309,11 +1309,13 @@ sub parse_modelinfo_file {
   # actually parse modelinfo file: 
   # example lines:
   # ---
-  # SSU_rRNA_archaea SSU Archaea ribo.0p02.SSU_rRNA_archaea.cm
-  # LSU_rRNA_eukarya LSU Eukarya ribo.0p02.LSU_rRNA_eukarya.cm
-  # *all*            -   -       ribo.0p02.cm
+  # SSU_rRNA_archaea  SSU Archaea ribo.0p02.SSU_rRNA_archaea.cm
+  # LSU_rRNA_eukarya  LSU Eukarya ribo.0p02.LSU_rRNA_eukarya.cm
+  # *all*             -   -       ribo.0p02.cm
+  # SSU_rRNA_bacteria LSU Eukarya -
   # ---
   # exactly one line must have model name as '*all*'
+  # models with '-' values in final column will be fetched from the *all* CM file as needed
   open(IN, $modelinfo_file) || ofile_FileOpenFailure($modelinfo_file, $sub_name, $!, "reading", $FH_HR);
   while(my $line = <IN>) { 
     if($line !~ m/^\#/ && $line =~ m/\w/) { # skip comment lines and blank lines
@@ -1323,37 +1325,39 @@ sub parse_modelinfo_file {
         ofile_FAIL("ERROR didn't read 4 tokens in model info input file $modelinfo_file, line $line", 1, $FH_HR);
       }
       my($model, $family, $domain, $cmfile) = (@el_A);
-      
-      # make sure that the model file exists, either in $df_model_dir or, if
-      # -i was used, in the same directory that $modelinfo_file is in
-      $df_model_file = $df_model_dir . $cmfile;
-      if($opt_i_used) { 
-        $non_df_model_file = $non_df_modelinfo_dir . $cmfile;
-        $in_nondf = utl_FileValidateExistsAndNonEmpty($non_df_model_file, undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
-        $in_df    = utl_FileValidateExistsAndNonEmpty($df_model_file,     undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
-        # if it exists in both places, use the -i specified version
-        if(($in_nondf == 0) && ($in_df == 0)) { 
-          ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, did not find it in the two places it's looked for:\ndirectory $non_df_modelinfo_dir (where model info file specified with -i is) AND\ndirectory $df_model_dir (default model directory)\n", 1, $ofile_info_HH{"FH"});
-        }
-        elsif(($in_nondf == -1) && ($in_df == 0)) { 
-          ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, it exists as $non_df_model_file but is empty", 1, $ofile_info_HH{"FH"});
-        }
-        elsif(($in_nondf == 0) && ($in_df == -1)) { 
-          ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, it exists as $df_model_file but is empty", 1, $ofile_info_HH{"FH"});
-        }
-       elsif($in_nondf == 1) { 
-          $cmfile = $non_df_model_file;
-        }
-        elsif($in_df == 1) { 
+
+      if($cmfile ne "-") { 
+        # make sure that the model file exists, either in $df_model_dir or, if
+        # -i was used, in the same directory that $modelinfo_file is in
+        $df_model_file = $df_model_dir . $cmfile;
+        if($opt_i_used) { 
+          $non_df_model_file = $non_df_modelinfo_dir . $cmfile;
+          $in_nondf = utl_FileValidateExistsAndNonEmpty($non_df_model_file, undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
+          $in_df    = utl_FileValidateExistsAndNonEmpty($df_model_file,     undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
+          # if it exists in both places, use the -i specified version
+          if(($in_nondf == 0) && ($in_df == 0)) { 
+            ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, did not find it in the two places it's looked for:\ndirectory $non_df_modelinfo_dir (where model info file specified with -i is) AND\ndirectory $df_model_dir (default model directory)\n", 1, $ofile_info_HH{"FH"});
+          }
+          elsif(($in_nondf == -1) && ($in_df == 0)) { 
+            ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, it exists as $non_df_model_file but is empty", 1, $ofile_info_HH{"FH"});
+          }
+          elsif(($in_nondf == 0) && ($in_df == -1)) { 
+            ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, it exists as $df_model_file but is empty", 1, $ofile_info_HH{"FH"});
+          }
+          elsif($in_nondf == 1) { 
+            $cmfile = $non_df_model_file;
+          }
+          elsif($in_df == 1) { 
+            $cmfile = $df_model_file;
+          }
+          else { 
+            ofile_FAIL("ERROR in $sub_name, looking for model file, unexpected situation (in_nondf: $in_nondf, in_df: $in_df)\n", 1, $ofile_info_HH{"FH"});
+          }
+        }     
+        else { # $opt_i_used is FALSE, -i not used, models must be in $df_model_dir
+          utl_FileValidateExistsAndNonEmpty($df_model_file, "model file name read from default model info file", $sub_name, 1, $FH_HR); # die if it doesn't exist
           $cmfile = $df_model_file;
         }
-        else { 
-          ofile_FAIL("ERROR in $sub_name, looking for model file, unexpected situation (in_nondf: $in_nondf, in_df: $in_df)\n", 1, $ofile_info_HH{"FH"});
-        }
-      }     
-      else { # $opt_i_used is FALSE, -i not used, models must be in $df_model_dir
-        utl_FileValidateExistsAndNonEmpty($df_model_file, "model file name read from default model info file", $sub_name, 1, $FH_HR); # die if it doesn't exist
-        $cmfile = $df_model_file;
       }
         
       if($model eq "*all*") { 
@@ -1394,6 +1398,13 @@ sub parse_modelinfo_file {
     }
   }
 
+  # go back and replace any individual cm file names of '-' with "fetch:<$master_cmfile>
+  foreach $model (keys %{$family_HR}) { 
+    if($indi_cmfile_HR->{$model} eq "-") {
+      $indi_cmfile_HR->{$model} = "fetch:" . $master_cmfile;
+    }
+  }
+    
   return ($master_cmfile, $master_blastdb_file);
 }
 
@@ -1531,7 +1542,8 @@ sub parse_and_validate_model_files {
   my $indi_cksum_output = undef;
   my @indi_cksum_A = ();
   my $indi_cmfile = undef;
-
+  my $do_fetch = 0;
+  
   my $nnames = scalar(@name_A);
   if($nnames != scalar(@cksum_A)) { 
     ofile_FAIL("ERROR in $sub_name, did not read the same number of names and checksum lines from master model file:\n$master_model_file", 1, $FH_HR); 
@@ -1543,25 +1555,28 @@ sub parse_and_validate_model_files {
   for(my $i = 0; $i < scalar(@name_A); $i++) { 
     $model = $name_A[$i];
     $cksum = $cksum_A[$i];
-    $indi_cmfile = $indi_cmfile_HR->{$model};
+    ($indi_cmfile, $do_fetch) = ribo_ParseStoredIndiCmFileName($indi_cmfile_HR->{$model});
+    
     if(! exists $tmp_family_model_H{$model}) { 
       ofile_FAIL("ERROR read model \"$model\" from model file $master_model_file that is not listed in the model info file.", 1, $FH_HR);
     }
     if($tmp_family_model_H{$model} == 0) { # only check if we haven't seen this name before
-      $indi_cksum_output = `grep -w ^CKSUM $indi_cmfile | awk '{ print \$2 }'`;
-      @indi_cksum_A = split("\n", $indi_cksum_output);
-      if(scalar(@indi_cksum_A) != 2) { 
-        ofile_FAIL("ERROR in $sub_name, did not read the expected 2 CKSUM lines from $indi_cmfile, it should have exactly 1 model and exactly 2 lines containing the token CKSUM in the entire file", 1, $FH_HR); 
+      if(! $do_fetch) { 
+        $indi_cksum_output = `grep -w ^CKSUM $indi_cmfile | awk '{ print \$2 }'`;
+        @indi_cksum_A = split("\n", $indi_cksum_output);
+        if(scalar(@indi_cksum_A) != 2) { 
+          ofile_FAIL("ERROR in $sub_name, did not read the expected 2 CKSUM lines from $indi_cmfile, it should have exactly 1 model and exactly 2 lines containing the token CKSUM in the entire file", 1, $FH_HR); 
+        }
+        if($indi_cksum_A[0] != $indi_cksum_A[1]) { 
+          ofile_FAIL("ERROR in $sub_name, the two CKSUM lines from $indi_cmfile differ unexpectedly", 1, $FH_HR); 
+        }
+        if($indi_cksum_A[0] != $cksum) { 
+          ofile_FAIL("ERROR in $sub_name, for model $model, checksum mismatch between the master CM file and the individual CM file\nmaster CM file: $master_model_file\nindividual CM file: $indi_cmfile\nAre you sure these models are the same? They are required to be identical.\n", 1, $FH_HR);
+        }
       }
-      if($indi_cksum_A[0] != $indi_cksum_A[1]) { 
-        ofile_FAIL("ERROR in $sub_name, the two CKSUM lines from $indi_cmfile differ unexpectedly", 1, $FH_HR); 
-      }
-      if($indi_cksum_A[0] != $cksum) { 
-        ofile_FAIL("ERROR in $sub_name, for model $model, checksum mismatch between the master CM file and the individual CM file\nmaster CM file: $master_model_file\nindividual CM file: $indi_cmfile\nAre you sure these models are the same? They are required to be identical.\n", 1, $FH_HR);
-      }
+      # if we get here, checksum test has passed, or $do_fetch was TRUE
+      $tmp_family_model_H{$model} = 1;
     }
-    # if we get here, checksum test has passed
-    $tmp_family_model_H{$model} = 1;
   }
 
   foreach $model (keys %tmp_family_model_H) { 

--- a/ribotyper
+++ b/ribotyper
@@ -15,7 +15,6 @@ my $env_riboscripts_dir  = utl_DirEnvVarValid("RIBOSCRIPTSDIR");
 my $env_riboinfernal_dir = utl_DirEnvVarValid("RIBOINFERNALDIR");
 my $env_riboeasel_dir    = utl_DirEnvVarValid("RIBOEASELDIR");
 my $env_riboblast_dir    = utl_DirEnvVarValid("RIBOBLASTDIR");
-my $df_model_dir         = $env_riboscripts_dir . "/models/";
 
 my %execs_H = (); # hash with paths to all required executables
 $execs_H{"cmsearch"}    = $env_riboinfernal_dir . "/cmsearch";
@@ -68,6 +67,7 @@ opt_Add("-f",           "boolean", 0,                       $g,    undef, undef,
 opt_Add("-v",           "boolean", 0,                       $g,    undef, undef,      "be verbose",                                     "be verbose; output commands to stdout as they're run", \%opt_HH, \@opt_order_A);
 opt_Add("-n",           "integer", 0,                       $g,    undef, "-p",       "use <n> CPUs",                                   "use <n> CPUs", \%opt_HH, \@opt_order_A);
 opt_Add("-i",           "string",  undef,                   $g,    undef, undef,      "use model info file <s> instead of default",     "use model info file <s> instead of default", \%opt_HH, \@opt_order_A);
+opt_Add("-m",           "string",  undef,                   $g,    undef, undef,      "model files are in directory <s>, not default",  "model files are in directory <s>, not default", \%opt_HH, \@opt_order_A);
 
 $opt_group_desc_H{++$g} = "options for controlling the first round search algorithm";
 #       option               type   default                group  requires incompat          preamble-output                            help-output    
@@ -168,6 +168,7 @@ my $options_okay =
                 'v'            => \$GetOptions_H{"-v"},
                 'n=s'          => \$GetOptions_H{"-n"},
                 'i=s'          => \$GetOptions_H{"-i"},
+                'm=s'          => \$GetOptions_H{"-m"},
 # first round algorithm options
                 '1hmm'          => \$GetOptions_H{"--1hmm"},
                 '1slow'         => \$GetOptions_H{"--1slow"},
@@ -440,7 +441,14 @@ foreach $cmd (@early_cmd_A) {
 }
 
 # make sure the sequence, qsubinfo and modelinfo files exist
-my $df_modelinfo_file = $df_model_dir . "ribotyper.modelinfo";
+my $model_dir = undef;
+if(! opt_IsUsed("-m", \%opt_HH)) { $model_dir = $env_riboscripts_dir . "/models/"; }
+else                             { $model_dir = opt_Get("-m", \%opt_HH); }
+if($model_dir !~ m/\/$/) {
+  $model_dir .= "/";
+}
+
+my $df_modelinfo_file = $model_dir . "ribotyper.modelinfo";
 my $modelinfo_file = undef;
 if(! opt_IsUsed("-i", \%opt_HH)) { $modelinfo_file = $df_modelinfo_file; }
 else                             { $modelinfo_file = opt_Get("-i", \%opt_HH); }
@@ -454,15 +462,13 @@ else { # -i used on the command line
 }
 
 # if -p, check for existence of qsub info file
-my $df_qsubinfo_file = $df_model_dir . "ribo.qsubinfo";
 my $qsubinfo_file = undef;
-
 if(opt_IsUsed("-p", \%opt_HH)) { 
-  if(! opt_IsUsed("-q", \%opt_HH)) { $qsubinfo_file = $df_qsubinfo_file; }
+  if(! opt_IsUsed("-q", \%opt_HH)) { $qsubinfo_file = $model_dir . "ribo.qsubinfo"; }
   else                             { $qsubinfo_file = opt_Get("-q", \%opt_HH); }
 
   if(! opt_IsUsed("-q", \%opt_HH)) {
-    utl_FileValidateExistsAndNonEmpty($qsubinfo_file, "default qsub info file", undef, 1, $ofile_info_HH{"FH"}); # '1' says: die if it doesn't exist or is empty
+    utl_FileValidateExistsAndNonEmpty($qsubinfo_file, "qsub info file in model dir ($model_dir)", undef, 1, $ofile_info_HH{"FH"}); # '1' says: die if it doesn't exist or is empty
   }
   else { # -q used on the command line
     utl_FileValidateExistsAndNonEmpty($qsubinfo_file, "qsub info file specified with -q", undef, 1, $ofile_info_HH{"FH"}); # 1 says: die if it doesn't exist or is empty
@@ -565,7 +571,7 @@ my $qsub_prefix   = undef; # qsub prefix for submitting jobs to the farm
 my $qsub_suffix   = undef; # qsub suffix for submitting jobs to the farm
 my $master_model_file   = undef; # path to master CM file
 my $master_blastdb_file = undef; # path to master blastn file
-($master_model_file, $master_blastdb_file) = parse_modelinfo_file($modelinfo_file, $df_model_dir, \%family_H, \%domain_H, \%indi_cmfile_H, \%opt_HH, $ofile_info_HH{"FH"});
+($master_model_file, $master_blastdb_file) = parse_modelinfo_file($modelinfo_file, $model_dir, \%family_H, \%domain_H, \%indi_cmfile_H, \%opt_HH, $ofile_info_HH{"FH"});
 
 # parse the model file and make sure that there is a 1:1 correspondence between 
 # models in the models file and models listed in the model info file
@@ -1262,7 +1268,7 @@ exit(0);
 #              
 # Arguments: 
 #   $modelinfo_file:  file to parse
-#   $df_model_dir:    default $RIBOSCRIPTSDIR/models directory, where default models should be
+#   $model_dir:       dir with models
 #   $family_HR:       ref to hash of family names, key is model name, value is family name
 #   $domain_HR:       ref to hash of domain names, key is model name, value is domain name
 #   $indi_cmfile_HR:  ref to hash of CM files, key is model name, value is path to CM file
@@ -1289,24 +1295,14 @@ sub parse_modelinfo_file {
   my $sub_name = "parse_modelinfo_file";
   if(scalar(@_) != $nargs_expected) { printf STDERR ("ERROR, $sub_name entered with %d != %d input arguments.\n", scalar(@_), $nargs_expected); exit(1); } 
 
-  my ($modelinfo_file, $df_model_dir, $family_HR, $domain_HR, $indi_cmfile_HR, $opt_HHR, $FH_HR) = @_;
+  my ($modelinfo_file, $model_dir, $family_HR, $domain_HR, $indi_cmfile_HR, $opt_HHR, $FH_HR) = @_;
 
   my $opt_i_used          = opt_IsUsed("-i", $opt_HHR);
   my $found_master        = 0;     # set to '1' when we find master file line
   my $master_cmfile       = undef; # name of 'master' CM file with all CMs
   my $master_blastdb_file = undef; # name of 'master' blastn db file
-  my $non_df_model_file   = undef; # non-default model file
-  my $df_model_file       = undef; # default model file
-  my $in_df;                       # flag for whether we found model file in default dir or not
-  my $in_nondf;                    # flag for whether we found model file in non-default dir or not
-
-  # determine directory that $modelinfo_file exists in if -i used, all models must 
-  # either be in this directory or in $df_model_dir
-  my $non_df_modelinfo_dir = undef; # directory with modelinfo file, if -i used
-  if($opt_i_used) { 
-    $non_df_modelinfo_dir = ribo_GetDirPath($modelinfo_file);
-  }
-
+  my $model_file          = undef; # model file
+  
   # actually parse modelinfo file: 
   # example lines:
   # ---
@@ -1328,45 +1324,17 @@ sub parse_modelinfo_file {
       my($model, $family, $domain, $cmfile) = (@el_A);
 
       if($cmfile ne "-") { 
-        # make sure that the model file exists, either in $df_model_dir or, if
+        # make sure that the model file exists
         # -i was used, in the same directory that $modelinfo_file is in
-        $df_model_file = $df_model_dir . $cmfile;
-        if($opt_i_used) { 
-          $non_df_model_file = $non_df_modelinfo_dir . $cmfile;
-          $in_nondf = utl_FileValidateExistsAndNonEmpty($non_df_model_file, undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
-          $in_df    = utl_FileValidateExistsAndNonEmpty($df_model_file,     undef, $sub_name, 0, $FH_HR); # don't die if it doesn't exist
-          # if it exists in both places, use the -i specified version
-          if(($in_nondf == 0) && ($in_df == 0)) { 
-            ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, did not find it in the two places it's looked for:\ndirectory $non_df_modelinfo_dir (where model info file specified with -i is) AND\ndirectory $df_model_dir (default model directory)\n", 1, $ofile_info_HH{"FH"});
-          }
-          elsif(($in_nondf == -1) && ($in_df == 0)) { 
-            ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, it exists as $non_df_model_file but is empty", 1, $ofile_info_HH{"FH"});
-          }
-          elsif(($in_nondf == 0) && ($in_df == -1)) { 
-            ofile_FAIL("ERROR in $sub_name, looking for model file $cmfile, it exists as $df_model_file but is empty", 1, $ofile_info_HH{"FH"});
-          }
-          elsif($in_nondf == 1) { 
-            $cmfile = $non_df_model_file;
-          }
-          elsif($in_df == 1) { 
-            $cmfile = $df_model_file;
-          }
-          else { 
-            ofile_FAIL("ERROR in $sub_name, looking for model file, unexpected situation (in_nondf: $in_nondf, in_df: $in_df)\n", 1, $ofile_info_HH{"FH"});
-          }
-        }     
-        else { # $opt_i_used is FALSE, -i not used, models must be in $df_model_dir
-          utl_FileValidateExistsAndNonEmpty($df_model_file, "model file name read from default model info file", $sub_name, 1, $FH_HR); # die if it doesn't exist
-          $cmfile = $df_model_file;
-        }
+        $cmfile = $model_dir . $cmfile;
+        utl_FileValidateExistsAndNonEmpty($cmfile, "model file read from model info file", $sub_name, 1, $FH_HR); # die if it doesn't exist
       }
-        
       if($model eq "*all*") { 
         if($found_master) { 
           ofile_FAIL("ERROR read model $model twice in $modelinfo_file", 1, $ofile_info_HH{"FH"});
         }
         $found_master = 1;
-        $master_cmfile       = $cmfile;
+        $master_cmfile = $cmfile;
         if($master_cmfile =~ m/\.cm$/) { 
           $master_blastdb_file = $cmfile;
           $master_blastdb_file =~ s/\.cm$/.fa/;
@@ -1399,10 +1367,10 @@ sub parse_modelinfo_file {
     }
   }
 
-  # go back and replace any individual cm file names of '-' with "fetch:<$master_cmfile>
+  # go back and replace any individual cm file names of '-' with fetch:<$master_cmfile>
   foreach $model (keys %{$family_HR}) { 
     if($indi_cmfile_HR->{$model} eq "-") {
-      $indi_cmfile_HR->{$model} = "model:$model\nfile:" . $master_cmfile;
+      $indi_cmfile_HR->{$model} = ribo_CreateStoredIndiCmFileName($model, $master_cmfile);
     }
   }
     

--- a/ribotyper
+++ b/ribotyper
@@ -20,6 +20,7 @@ my $df_model_dir         = $env_riboscripts_dir . "/models/";
 my %execs_H = (); # hash with paths to all required executables
 $execs_H{"cmsearch"}    = $env_riboinfernal_dir . "/cmsearch";
 $execs_H{"cmalign"}     = $env_riboinfernal_dir . "/cmalign";
+$execs_H{"cmfetch"}     = $env_riboinfernal_dir . "/cmfetch";
 $execs_H{"esl-seqstat"} = $env_riboeasel_dir    . "/esl-seqstat";
 $execs_H{"esl-sfetch"}  = $env_riboeasel_dir    . "/esl-sfetch";
 # we'll check for blastn below after we find out if we need it (if --1blast)
@@ -1401,7 +1402,7 @@ sub parse_modelinfo_file {
   # go back and replace any individual cm file names of '-' with "fetch:<$master_cmfile>
   foreach $model (keys %{$family_HR}) { 
     if($indi_cmfile_HR->{$model} eq "-") {
-      $indi_cmfile_HR->{$model} = "fetch:" . $master_cmfile;
+      $indi_cmfile_HR->{$model} = "model:$model\nfile:" . $master_cmfile;
     }
   }
     
@@ -1543,6 +1544,7 @@ sub parse_and_validate_model_files {
   my @indi_cksum_A = ();
   my $indi_cmfile = undef;
   my $do_fetch = 0;
+  my $parsed_model = undef;
   
   my $nnames = scalar(@name_A);
   if($nnames != scalar(@cksum_A)) { 
@@ -1555,8 +1557,10 @@ sub parse_and_validate_model_files {
   for(my $i = 0; $i < scalar(@name_A); $i++) { 
     $model = $name_A[$i];
     $cksum = $cksum_A[$i];
-    ($indi_cmfile, $do_fetch) = ribo_ParseStoredIndiCmFileName($indi_cmfile_HR->{$model});
-    
+    ($indi_cmfile, $parsed_model, $do_fetch) = ribo_ParseStoredIndiCmFileName($indi_cmfile_HR->{$model});
+    if(($do_fetch) && ($model ne $parsed_model)) { 
+      ofile_FAIL("ERROR problem dealing with parsed model file name read for model $model", 1, $FH_HR);
+    }    
     if(! exists $tmp_family_model_H{$model}) { 
       ofile_FAIL("ERROR read model \"$model\" from model file $master_model_file that is not listed in the model info file.", 1, $FH_HR);
     }

--- a/testfiles/ribotyper.testin
+++ b/testfiles/ribotyper.testin
@@ -22,4 +22,9 @@ desc: ribotyper-2-100
 out: r100/r100.ribotyper.short.out
 exp: @RIBOSCRIPTSDIR@/testfiles/expected-files/r100.ribotyper.short.out
 rmdir: r100
-
+# test -i with a modelinfo file that doesn't list individual CMs, to test cmfetch capability from master cm file
+command: cp $RIBOSCRIPTSDIR/testfiles/example-16.fa ./; perl $RIBOSCRIPTSDIR/ribotyper -i $RIBOSCRIPTSDIR/testfiles/fetch.ribotyper.modelinfo -f example-16.fa itest-16 > /dev/null;
+desc: ribotyper-i1-16
+out: itest-16/itest-16.ribotyper.short.out
+exp: @RIBOSCRIPTSDIR@/testfiles/expected-files/test-16.ribotyper.short.out
+rmdir: itest-16


### PR DESCRIPTION
This eliminates need for individual CM files for ribotyper, which reduces total size of model files. Addresses issue #9 .

In modelinfo file, use '-' for name of individual CM file name to tell ribotyper to fetch this CM from the master CM file (read in "*all*" line). Master model file must be indexed with `cmfetch --index master.cm` or `cmpress master.cm`. ribotyper will check that this has been done. To minimize space, use `cmfetch --index master.cm` to create the `master.cm.ssi` file.